### PR TITLE
replaced zend logger with custom logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.2.14
+Released on 2022-01-07
+Release notes:
+
+- Replaced Zend module with Magento's native logging module.
+
 ### Salesfire v1.2.13
 Released on 2021-09-16
 Release notes:

--- a/Cron/Feed.php
+++ b/Cron/Feed.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Cron;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version.   1.2.12
+ * @version.   1.2.14
  */
 class Feed
 {

--- a/Cron/Feed.php
+++ b/Cron/Feed.php
@@ -20,7 +20,6 @@ class Feed
     private $_taxHelper;
     private $_stockItem;
 
-    private $_writer;
     private $_logger;
 
     private $mediaPath;
@@ -34,7 +33,8 @@ class Feed
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Framework\Filesystem\Driver\File $file,
         \Magento\Catalog\Helper\Data $taxHelper,
-        \Magento\CatalogInventory\Model\Stock\StockItemRepository $stockItem
+        \Magento\CatalogInventory\Model\Stock\StockItemRepository $stockItem,
+        \Salesfire\Salesfire\Helper\Logger\Logger $logger
     ) {
         $this->_helperData                = $helperData;
         $this->_storeManager              = $storeManager;
@@ -46,9 +46,7 @@ class Feed
         $this->_taxHelper                 = $taxHelper;
         $this->_stockItem                 = $stockItem;
 
-        $this->_writer = new \Zend\Log\Writer\Stream(BP . '/var/log/salesfire.log');
-        $this->_logger = new \Zend\Log\Logger();
-        $this->_logger->addWriter($this->_writer);
+        $this->_logger = $logger;
 
         $this->mediaPath = $this->_filesystem->getDirectoryRead(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA)->getAbsolutePath() . 'catalog';
 

--- a/Helper/Logger/Handler.php
+++ b/Helper/Logger/Handler.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Salesfire\Salesfire\Helper\Logger;
+ 
+use Magento\Framework\Logger\Handler\Base;
+use Monolog\Logger;
+ 
+class Handler extends Base
+{
+    protected $loggerType = Logger::INFO;
+ 
+    protected $fileName = '/var/log/salesfire.log';
+}

--- a/Helper/Logger/Handler.php
+++ b/Helper/Logger/Handler.php
@@ -5,6 +5,13 @@ namespace Salesfire\Salesfire\Helper\Logger;
 use Magento\Framework\Logger\Handler\Base;
 use Monolog\Logger;
  
+/**
+ * Salesfire Logging Handler
+ *
+ * @category   Salesfire
+ * @package    Salesfire_Salesfire
+ * @version.   1.2.14
+ */
 class Handler extends Base
 {
     protected $loggerType = Logger::INFO;

--- a/Helper/Logger/Logger.php
+++ b/Helper/Logger/Logger.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Salesfire\Salesfire\Helper\Logger;
+ 
+/**
+ * Using Magento's native logger class as a replacement for Zend which is not included with the Magento framework anymore.
+ * https://community.magento.com/t5/Magento-DevBlog/Migration-of-Zend-Framework-to-the-Laminas-Project/ba-p/443251
+ */
+class Logger extends \Monolog\Logger
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.2.13",
+    "version": "1.2.14",
     "license": [
         "OSL-3.0"
     ],

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+ <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Salesfire\Salesfire\Helper\Logger\Handler">
+        <arguments>
+            <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+        </arguments>
+    </type>
+    <type name="Salesfire\Salesfire\Helper\Logger\Logger">
+        <arguments>
+            <argument name="name" xsi:type="string">salesfireLogger</argument>
+            <argument name="handlers"  xsi:type="array">
+                <item name="system" xsi:type="object">Salesfire\Salesfire\Helper\Logger\Handler</item>
+            </argument>
+        </arguments>
+    </type>
+</config>


### PR DESCRIPTION
This is a needed change due to ```Zend``` Framework no longer being used within Magento's framework. The change by their team introduced non-backward compatible changes, so this is a fix for it. 

Their new framework ```Laminas Logger``` (a direct replacement for Zend) could've been used here but it is a modular package and would need to be pulled as a dependency and therefore I opted for the use of Magento's native logging library 
without the need for external packages. 

More information about it is here
https://community.magento.com/t5/Magento-DevBlog/Migration-of-Zend-Framework-to-the-Laminas-Project/ba-p/443251
