### PR TITLE
Add Content Security Policy whitelist file

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="salesfire" type="host">cdn.salesfire.co.uk</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="salesfire" type="host">hit.salesfire.co.uk</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
The absence of a csp_whitelist.xml file was resulting in CSP violation messages being written to the browser console when viewing a Magento site with this extension installed.

This change just adds a csp_whitelist.xml file containing the hosts cdn.salesfire.co.uk and hit.salesfire.co.uk so that these will be added to the Content Security Policy for the site and these errors/warnings will no longer be generated.
