### PR TITLE
fix: [sc-7916] Magento 2 feed generations adds some product with VAT included and some without VAT included in the price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Released on 2023-12-13
 Released notes:
 
-- Update feed generation to use tax settings when calculating price.
+- Update feed generator to use tax settings when calculating price.
 
 ### Salesfire v1.4.2
 Released on 2023-12-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.4.3
+Released on 2023-12-13
+Released notes:
+
+- Update feed generation to use tax settings when calculating price.
+
 ### Salesfire v1.4.2
 Released on 2023-12-11
 Released notes:
@@ -56,7 +62,7 @@ Released notes:
 Released on 2023-06-20
 Released notes:
 
-- Removed trailing comma's in the function calls that were causing feed errors. 
+- Removed trailing comma's in the function calls that were causing feed errors.
 
 ### Salesfire v1.3.4
 Released on 2023-05-17

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.1
+ * @version    1.4.3
  */
 class Generator
 {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Story details: https://app.shortcut.com/salesfire/story/7916