### PR TITLE
fix(integrations & plugins): [sc-8194] Magento 2 plugin feed generator isn't setting the correct sale price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.4.6
+Released on 2024-01-18
+Released notes:
+
+- Fix bug where sale price isn't always included in feed.
+
 ### Salesfire v1.4.5
 Released on 2023-12-14
 Released notes:

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -46,7 +46,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.4.4';
+        return '1.4.6';
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.5
+ * @version    1.4.6
  */
 class Generator
 {
@@ -584,9 +584,8 @@ class Generator
 
         foreach ($usedProds as $child) {
             if ($child->getId() != $product->getId()) {
-                $price = $price === null ?
-                    $child->getPrice($type)
-                    : min($child->getPrice($type), $price);
+                $child_price = $child->getPriceInfo()->getPrice($type)->getAmount()->getBaseAmount();
+                $price = $price === null ? $child_price : min($child_price, $price);
             }
         }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Story details: https://app.shortcut.com/salesfire/story/8194