### PR TITLE
fix(integrations & plugins): [sc-9614] Magento 2 dynamic store manager property creation is deprecated

### DIFF
--- a/Block/Adminhtml/FeedUrl.php
+++ b/Block/Adminhtml/FeedUrl.php
@@ -16,7 +16,7 @@ use Salesfire\Salesfire\Helper\Data;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.3.3
+ * @version    1.4.15
  */
 class FeedUrl extends Field
 {

--- a/Block/Adminhtml/FeedUrl.php
+++ b/Block/Adminhtml/FeedUrl.php
@@ -31,6 +31,11 @@ class FeedUrl extends Field
     private $secureRenderer;
 
     /**
+     * @var StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
      * @param Context $context
      * @param StoreManagerInterface $storeManager
      * @param Data $helperData

--- a/Block/Adminhtml/Logs.php
+++ b/Block/Adminhtml/Logs.php
@@ -17,7 +17,7 @@ use \Salesfire\Salesfire\Helper\Logger\Logger;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.0
+ * @version    1.4.15
  */
 class Logs extends Field
 {

--- a/Block/Adminhtml/Logs.php
+++ b/Block/Adminhtml/Logs.php
@@ -32,6 +32,16 @@ class Logs extends Field
     private $secureRenderer;
 
     /**
+     * @var StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
+     * @var Logger
+     */
+    protected $_logger;
+
+    /**
      * @param Context $context
      * @param StoreManagerInterface $storeManager
      * @param Data $helperData

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.4.15
+Released on 2024-09-09
+Released notes:
+
+- Fix php 8.3 compatibility.
+
 ### Salesfire v1.4.14
 Released on 2024-08-15
 Released notes:

--- a/Controller/Config/Index.php
+++ b/Controller/Config/Index.php
@@ -6,7 +6,7 @@ namespace Salesfire\Salesfire\Controller\Config;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.3.3
+ * @version    1.4.15
  */
 class Index extends \Magento\Framework\App\Action\Action
 {

--- a/Controller/Config/Index.php
+++ b/Controller/Config/Index.php
@@ -12,6 +12,7 @@ class Index extends \Magento\Framework\App\Action\Action
 {
     protected $_jsonFactory;
     protected $_productMetadata;
+    protected $_storeManager;
     public $helperData;
 
     public function __construct(

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.14
+ * @version    1.4.15
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.4.14';
+        return '1.4.15';
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.4.14",
+    "version": "1.4.15",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Story details: https://app.shortcut.com/salesfire/story/9614

Fixes php 8.3 compatibility on magento v2.4.7. Dynamic property creation is no longer supported. Declaring class properties fixes this issue.

Feed, log and config page have all been tested and are working as expected.