### PR TITLE
fix(integrations & plugins): [sc-10204] Fix Magento error on SC-10204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.2
+Released on 2025-01-06
+Released notes:
+
+- Add constructor to the Logger class to provide a default value for the name parameter and ensure proper initialisation
+
 ### Salesfire v1.4.17
 Released on 2024-10-03
 Released notes:

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.17
+ * @version    1.5.2
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.4.17';
+        return '1.5.2';
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.17
+ * @version    1.5.2
  */
 class Generator
 {

--- a/Helper/Logger/Logger.php
+++ b/Helper/Logger/Logger.php
@@ -19,6 +19,11 @@ class Logger extends \Monolog\Logger
 {
     const MAX_SIZE =  1024 * 1024 * 50; // 50 megabytes
 
+    public function __construct($name = 'salesfire', array $handlers = [], array $processors = [])
+    {
+        parent::__construct($name, $handlers, $processors);
+    }
+
     protected function getPath()
     {
         /** @var \App\Logger\Handler $handlers */

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.4.17",
+    "version": "1.5.2",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Story details: https://app.shortcut.com/salesfire/story/10204

### Overview
The Salesfire Logger (Salesfire\Salesfire\Helper\Logger\Logger) was causing a critical error in some environments.

`Type Error occurred when creating object: Salesfire\Salesfire\Helper\Logger\Logger, 
Monolog\Logger::__construct(): Argument #1 ($name) must be of type string, null given
`

Upon investigation, it was found that despite specifying the logger's configuration (name: salesfire) in di.xml, this configuration was being bypassed in certain cases. This led to the logger being initialised without the required name argument, causing the error.

---

### Work
To address this issue, a constructor was added to the Logger class (Salesfire\Salesfire\Helper\Logger\Logger) to provide a default value for the name parameter and ensure proper initialisation.

---

### Consideration
Will bump the version and update the changelog once this pr (https://github.com/salesfire/magento2/pull/64) is merged.

---

### Testing
Verified that the logger is correctly initialized with the name 'salesfire' during runtime.
