### PR TITLE
WHEN I import my Magento 2 feed I WANT TO ensure that there aren't any errors as a result of special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.3
+Released on 2025-02-03
+Released notes:
+
+- Improves product description generation to cater for non UTF-8 characters
+
 ### Salesfire v1.5.2
 Released on 2025-01-06
 Released notes:

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.2
+ * @version    1.5.3
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.2';
+        return '1.5.3';
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -205,7 +205,7 @@ class Generator
 
                         $description = $category->getDescription();
                         if (! empty($description)) {
-                            $text[] = ['<description><![CDATA['.$this->escapeString(substr($this->_escaper->escapeHtml(strip_tags($description)), 0, 2000)).']]></description>', 3];
+                            $text[] = ['<description><![CDATA['.$this->escapeString(mb_substr($this->_escaper->escapeHtml(strip_tags($description)), 0, 2000)).']]></description>', 3];
                         }
 
                         $text[] = ['<link><![CDATA[' . $category->getUrl(true) . ']]></link>', 3];
@@ -255,7 +255,7 @@ class Generator
 
                             $text[] = ['<title><![CDATA[' . $this->escapeString($product->getName()) . ']]></title>', 3];
 
-                            $text[] = ['<description><![CDATA[' . $this->escapeString(substr($this->_escaper->escapeHtml(strip_tags($product->getDescription() ?: '')), 0, 5000)) . ']]></description>', 3];
+                            $text[] = ['<description><![CDATA[' . $this->escapeString(mb_substr($this->_escaper->escapeHtml(strip_tags($product->getDescription() ?: '')), 0, 5000)) . ']]></description>', 3];
 
                             $price = $this->getProductPrice($product);
                             $saleprice = $this->getProductSalePrice($product);

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.2
+ * @version    1.5.3
  */
 class Generator
 {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         }
     ],
     "require": {
-        "salesfire/salesfire": "^1.0.4",
-        "symfony/polyfill-mbstring": "^1.31"
+        "salesfire/salesfire": "^1.0.4"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "salesfire/salesfire": "^1.0.4"
+        "salesfire/salesfire": "^1.0.4",
+        "symfony/polyfill-mbstring": "^1.31"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
[WHEN I import my Magento 2 feed I WANT TO ensure there aren't any errors as a result of special characters](https://app.shortcut.com/salesfire/story/10633/when-i-import-my-magento-2-feed-i-want-to-ensure-there-aren-t-any-errors-as-a-result-of)

---

### Overview
Currently, when we import a Magento2 feed sometimes it fails because `substr()` truncates a string in the middle of a multi-byte character. When this happens, the XML output contains invalid characters, leading to parsing errors, and the whole import fails.

This is because `substr()` is not UTF-8 aware, so it may break a multi-byte character by cutting only part of it, resulting in a corrupted xml.

---

### Work
Replaced `substr()` with `mb_substr()` for description generation, which is UTF-8 safe and correctly handles multi-byte characters. Also added `symfony/polyfill-mbstring` to ensure `mb_substr()` is available to us. 

---

### Considerations
Assuming its ok to add this dependency for this repo?

---

### Visual Evidence
[Import Log](https://imgur.com/a/L5uzqcy)
[Error Message](https://imgur.com/a/EkINRK4)
[Problem Char](https://imgur.com/a/vsjiIvr)

---

### Testing
N/A

[sc-10633]
