### PR TITLE
Bug: Magento ignores stock_qty when a store utilises multi source inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.6
+Released on 2025-03-25
+Released notes:
+
+- Fixed multi source inventory quantity
+
 ### Salesfire v1.5.5
 Released on 2025-03-11
 Released notes:

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.5
+ * @version    1.5.6
  */
 class Data extends AbstractHelper
 {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.5';
+        return '1.5.6';
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.5
+ * @version    1.5.6
  */
 class Generator
 {

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -379,7 +379,7 @@ class Generator
 
                                         $text[] = ['<mpn><![CDATA['.$this->escapeString($childProduct->getSku()).']]></mpn>', 5];
 
-                                        $text[] = ['<stock>' . $this->getStockQty($product, $childProduct) .'</stock>', 5];
+                                        $text[] = ['<stock>' . $this->getStockQty($product, $storeId, $childProduct) .'</stock>', 5];
 
                                         $text[] = ['<link><![CDATA[' . $this->getProductUrl($product, $storeId) . ']]></link>', 5];
 
@@ -430,7 +430,7 @@ class Generator
 
                                 $text[] = ['<mpn><![CDATA['.$this->escapeString($product->getSku()).']]></mpn>', 5];
 
-                                $text[] = ['<stock>' . $this->getStockQty($product) .'</stock>', 5];
+                                $text[] = ['<stock>' . $this->getStockQty($product, $storeId) .'</stock>', 5];
 
                                 $text[] = ['<link><![CDATA[' . $this->getProductUrl($product, $storeId, false) . ']]></link>', 5];
 
@@ -643,10 +643,11 @@ class Generator
         return null;
     }
 
-    protected function getStockQty($product, $childProduct = null)
+    protected function getStockQty($product, $storeId, $childProduct = null)
     {
+
         if ($childProduct) {
-            $parent_stock = $this->getStockQty($product);
+            $parent_stock = $this->getStockQty($product, $storeId);
 
             if ($parent_stock === 0) {
                 return 0;
@@ -659,7 +660,17 @@ class Generator
             $default_stock_provider = $this->_objectManager->create(\Magento\InventoryCatalogApi\Api\DefaultStockProviderInterface::class);
             $stock_item_data = $this->_objectManager->create(\Magento\InventorySalesApi\Model\GetStockItemDataInterface::class);
 
-            $default_stock_id = $default_stock_provider->getId();
+            try {
+                $websiteCode = $this->_storeManager->getStore($storeId)->getWebsite()->getCode();
+                $default_stock_id = $this->_objectManager
+                    ->get(\Magento\InventorySalesApi\Api\StockResolverInterface::class)
+                    ->execute($websiteCode)
+                    ->getStockId();
+            } catch (\Exception $e) {
+                // If MSI isn't enabled fallback to default.
+                $default_stock_id = $default_stock_provider->getId();
+            }
+
             $stock_item = $stock_item_data->execute($product->getSku(), $default_stock_id);
 
             $is_salable = $stock_item[\Magento\InventorySalesApi\Model\GetStockItemDataInterface::IS_SALABLE] ?? false;
@@ -684,7 +695,7 @@ class Generator
             $stock = ($stock_item && $stock_item->getIsInStock()) ? ($stock_item->getQty() > 0 ? (int) $stock_item->getQty() : 1) : 0;
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
             $stock_state = $this->_objectManager->get('\Magento\CatalogInventory\Api\StockStateInterface');
-            $stock = $stock_state->getStockQty($product->getId());
+            $stock = $stock_state->getStockQty($product->getId(), $storeId);
         }
 
         return $stock ? $stock : 0;

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -664,7 +664,7 @@ class Generator
                 $websiteCode = $this->_storeManager->getStore($storeId)->getWebsite()->getCode();
                 $default_stock_id = $this->_objectManager
                     ->get(\Magento\InventorySalesApi\Api\StockResolverInterface::class)
-                    ->execute($websiteCode)
+                    ->execute('website', $websiteCode)
                     ->getStockId();
             } catch (\Exception $e) {
                 // If MSI isn't enabled fallback to default.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.5",
+    "version": "1.5.6",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Story: https://app.shortcut.com/salesfire/story/11046/bug-megento-ignores-stock-qty-when-a-store-utilises-multi-source-inventory

---

### Overview
A client reported that stock levels appeared as zero when using Magento’s Multi Source Inventory (MSI). This PR updates our stock fetching logic to support MSI when it’s enabled, while falling back to default stock otherwise.

---

### Work
- Retrieves stock using the MSI stock resolver when MSI is active.
- Falls back to default stock logic when MSI is not enabled.

---

### Considerations
When a website is assigned to a custom stock in MSI, Magento ignores the Default Source. So if a product only has stock in Default, saleble qty will be 0.

---

### Visual Evidence
<img width="1599" alt="image" src="https://github.com/user-attachments/assets/bc3c0870-e20e-4307-b34b-1c344869875e" />
<img width="1117" alt="image" src="https://github.com/user-attachments/assets/cf5bbf14-9019-409c-9410-8047bf502d81" />

---

### Testing
1. [Set up Magento locally and enable the Salesfire module](https://app.shortcut.com/salesfire/write/IkRvYyI6I3V1aWQgIjY0MTIxMDdiLThjZGItNGEzMS1iZmUzLWFlNmM5MmRiMWUxOSI=)
2. [Setup Multi Source Inventory](https://www.mgt-commerce.com/tutorial/magento-multi-source-inventory/) - making sure that your new stock source is set for the main website.
3. Once MSI is set up, update a product to point to that source and give it some stock.
4. Visit admin > store > configuration > Salesfire > general.
5. Enable product feed and click the "Force Feed Generation" button.
6. View the XML it generates (https://magento.test/media/catalog/0000.xml) and find your product, the stock level should match what you set with MSI.