### PR TITLE
Fix discount price tracking in order transactions

### DIFF
--- a/Block/Script.php
+++ b/Block/Script.php
@@ -143,13 +143,19 @@ class Script extends Template
                     }, $options['attribute_info']));
                 }
 
+                $quantity = $product->getQtyOrdered() ?: 1;
+                $totalAfterDiscountsBeforeTax = $product->getRowTotal() ?: 0;
+                $itemPriceAfterDiscounts = $quantity > 0 ? $totalAfterDiscountsBeforeTax / $quantity : 0;
+                $taxOnDiscountedTotal = $product->getTaxAmount() ?: 0;
+                $itemTaxOnDiscountedPrice = $quantity > 0 ? $taxOnDiscountedTotal / $quantity : 0;
+
                 $transaction->addProduct(new \Salesfire\Types\Product([
                     'sku'        => $product_id,
                     'parent_sku' => $parent_product_id,
                     'name'       => $product->getName(),
-                    'price'      => round($product->getPrice(), 2),
-                    'tax'        => round($product->getTaxAmount(), 2),
-                    'quantity'   => round($product->getQtyOrdered(), 2),
+                    'price'      => round($itemPriceAfterDiscounts, 2),
+                    'tax'        => round($itemTaxOnDiscountedPrice, 2),
+                    'quantity'   => round($quantity, 2),
                     'variant'    => $variant,
                 ]));
             }

--- a/Block/Script.php
+++ b/Block/Script.php
@@ -144,9 +144,12 @@ class Script extends Template
                 }
 
                 $quantity = $product->getQtyOrdered() ?? 1;
+
+                // These totals are for all items in this order line (e.g., if qty=4, this is the total for all 4)
                 $totalAfterDiscountsBeforeTax = $product->getRowTotal() ?: 0;
-                $itemPriceAfterDiscounts = $quantity > 0 ? $totalAfterDiscountsBeforeTax / $quantity : 0;
                 $taxOnDiscountedTotal = $product->getTaxAmount() ?: 0;
+
+                $itemPriceAfterDiscounts = $quantity > 0 ? $totalAfterDiscountsBeforeTax / $quantity : 0;
                 $itemTaxOnDiscountedPrice = $quantity > 0 ? $taxOnDiscountedTotal / $quantity : 0;
 
                 $transaction->addProduct(new \Salesfire\Types\Product([

--- a/Block/Script.php
+++ b/Block/Script.php
@@ -143,7 +143,7 @@ class Script extends Template
                     }, $options['attribute_info']));
                 }
 
-                $quantity = $product->getQtyOrdered() ?: 1;
+                $quantity = $product->getQtyOrdered() ?? 1;
                 $totalAfterDiscountsBeforeTax = $product->getRowTotal() ?: 0;
                 $itemPriceAfterDiscounts = $quantity > 0 ? $totalAfterDiscountsBeforeTax / $quantity : 0;
                 $taxOnDiscountedTotal = $product->getTaxAmount() ?: 0;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.8
+Released on 2025-10-07
+Released notes:
+
+- Fix discount price tracking in order transactions
+
 ### Salesfire v1.5.7
 Released on 2025-03-31
 Released notes:

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.6
+ * @version    1.5.8
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.7';
+        return '1.5.8';
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.6
+ * @version    1.5.8
  */
 class Generator
 {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.7",
+    "version": "1.5.8",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Scenario : customer purchases quantity 3 of a £10 product and uses a 10% discount 

### Before: 
  - `$product->getPrice()` returns £10 (catalog price, **ignoring** the 10% discount)
  - `$product->getTaxAmount()` returns the total tax for all 3 items (e.g., £5.40 total)
  - Sent to Salesfire: price: £10, tax: £5.40, quantity: 3
  - Salesfire assumes that tax is per item and calculates total tax as £5.40 × 3 = £16.20 (vendor/salesfire/salesfire/src/Types/Transaction.php:251-256)


### After:
  - `$product->getRowTotal()` returns £27 (3 items × £10 × 0.9 discount = £27 total after discount)
  - Divide by quantity: £27 ÷ 3 = £9 per item
  - `$product->getTaxAmount()` returns £5.40 total tax for all 3 items
  - Divide by quantity: £5.40 ÷ 3 = £1.80 per item
  - Sent to Salesfire: price: £9, tax: £1.80, quantity: 3
  - Salesfire calculates total tax as £1.80 × 3 = £5.40 ✅