### PR TITLE
Add basket tracking logic

### DIFF
--- a/Block/Script.php
+++ b/Block/Script.php
@@ -207,7 +207,7 @@ class Script extends Template
             $nonce = $cspNonceProvider->generateNonce();
         }
 
-        return $this->initSfGetIdScript($nonce) . $formatter->toScriptTag($nonce);
+        return $this->initSfGetIdScript($nonce) . $this->initSfAddToCartScript($nonce) . $formatter->toScriptTag($nonce);
     }
 
     /**

--- a/Block/Script.php
+++ b/Block/Script.php
@@ -5,6 +5,7 @@ use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\ObjectManagerInterface;
 use \Magento\Framework\App\ObjectManager;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Salesfire Script Block
@@ -38,6 +39,10 @@ class Script extends Template
      * @var \Magento\Framework\App\ObjectManager
      */
     private $_objectManager;
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $_storeManager;
 
     public function __construct(
         Context $context,
@@ -46,6 +51,7 @@ class Script extends Template
         \Magento\Framework\App\Request\Http $request,
         \Magento\Framework\Registry $registry,
         \Magento\Catalog\Helper\Data $taxHelper,
+        StoreManagerInterface $storeManager,
         array $data = []
     ) {
         $this->helperData      = $helperData;
@@ -53,6 +59,7 @@ class Script extends Template
         $this->request         = $request;
         $this->registry        = $registry;
         $this->taxHelper       = $taxHelper;
+        $this->_storeManager   = $storeManager;
         $this->_objectManager  = ObjectManager::getInstance();
         parent::__construct($context, $data);
     }
@@ -104,6 +111,25 @@ class Script extends Template
         $script .= "});\n";
         $script .= "</script>\n";
     
+        return $script;
+    }
+
+    public function initSfAddToCartScript($nonce = null)
+    {
+        $script = "<script";
+
+        if ($nonce) {
+            $script .= " nonce=\"{$nonce}\"";
+        }
+
+        $currencyCode = $this->_storeManager->getStore()->getCurrentCurrencyCode();
+
+        $script .= ">\n";
+        $script .= "window.sfData = window.sfData || {};\n";
+        $script .= "window.sfData.currency = '{$currencyCode}';\n";
+        $script .= "require(['sfcarttracking']);\n";
+        $script .= "</script>\n";
+
         return $script;
     }
 

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -2,6 +2,7 @@ const config = {
     map: {
         '*': {
             sfgetid: 'Salesfire_Salesfire/js/sfgetid',
+            sfcarttracking: 'Salesfire_Salesfire/js/cart-tracking',
         }
     }
 };

--- a/view/frontend/web/js/cart-tracking.js
+++ b/view/frontend/web/js/cart-tracking.js
@@ -95,7 +95,7 @@ define([
         };
 
         eventData.ecommerce[eventType] = {
-            'sku': product.product_sku,
+            'sku': product.product_id,
             'name': product.product_name,
             'price': product.product_price_value,
             'quantity': qty,

--- a/view/frontend/web/js/cart-tracking.js
+++ b/view/frontend/web/js/cart-tracking.js
@@ -9,7 +9,7 @@ define([
      * A variable to hold a deep copy of the cart data from the previous state.
      * This is used to compare against the new state to detect changes.
      */
-    var prevCartData = {};
+    let prevCartData = {};
 
     /**
      * Compares the new cart state with the old to find any added products or increased quantities.
@@ -19,13 +19,13 @@ define([
      * @returns {Object|null} The added product item or null if none is found.
      */
     function findAddedProduct(newCart, oldCart) {
-        var oldItems = oldCart.items || [];
-        var newItems = newCart.items || [];
-        var oldItemsBySku = _.indexBy(oldItems, 'product_sku');
-        var newItemsBySku = _.indexBy(newItems, 'product_sku');
+        const oldItems = oldCart.items || [];
+        const newItems = newCart.items || [];
+        const oldItemsBySku = _.indexBy(oldItems, 'product_sku');
+        const newItemsBySku = _.indexBy(newItems, 'product_sku');
 
         // Case 1: A completely new SKU has been added to the cart.
-        var newItemSku = _.find(_.keys(newItemsBySku), function (sku) {
+        const newItemSku = _.find(_.keys(newItemsBySku), function (sku) {
             return !oldItemsBySku[sku];
         });
 
@@ -34,12 +34,12 @@ define([
         }
 
         // Case 2: The quantity of an existing SKU has been increased.
-        var updatedItemSku = _.find(_.keys(newItemsBySku), function (sku) {
+        const updatedItemSku = _.find(_.keys(newItemsBySku), function (sku) {
             return oldItemsBySku[sku] && parseInt(newItemsBySku[sku].qty) > parseInt(oldItemsBySku[sku].qty);
         });
 
         if (updatedItemSku) {
-            var item = $.extend(true, {}, newItemsBySku[updatedItemSku]);
+            const item = $.extend(true, {}, newItemsBySku[updatedItemSku]);
             item.qty_diff = parseInt(item.qty) - parseInt(oldItemsBySku[updatedItemSku].qty);
             return item;
         }
@@ -55,13 +55,13 @@ define([
      * @returns {Object|null} The removed product item or null if none is found.
      */
     function findRemovedProduct(newCart, oldCart) {
-        var oldItems = oldCart.items || [];
-        var newItems = newCart.items || [];
-        var oldItemsBySku = _.indexBy(oldItems, 'product_sku');
-        var newItemsBySku = _.indexBy(newItems, 'product_sku');
+        const oldItems = oldCart.items || [];
+        const newItems = newCart.items || [];
+        const oldItemsBySku = _.indexBy(oldItems, 'product_sku');
+        const newItemsBySku = _.indexBy(newItems, 'product_sku');
 
         // Case 1: An SKU has been completely removed from the cart.
-        var removedItemSku = _.find(_.keys(oldItemsBySku), function (sku) {
+        const removedItemSku = _.find(_.keys(oldItemsBySku), function (sku) {
             return !newItemsBySku[sku];
         });
 
@@ -70,12 +70,12 @@ define([
         }
 
         // Case 2: The quantity of an existing SKU has been decreased.
-        var updatedItemSku = _.find(_.keys(newItemsBySku), function (sku) {
+        const updatedItemSku = _.find(_.keys(newItemsBySku), function (sku) {
             return oldItemsBySku[sku] && parseInt(newItemsBySku[sku].qty) < parseInt(oldItemsBySku[sku].qty);
         });
 
         if (updatedItemSku) {
-            var item = $.extend(true, {}, oldItemsBySku[updatedItemSku]);
+            const item = $.extend(true, {}, oldItemsBySku[updatedItemSku]);
             item.qty_diff = parseInt(oldItemsBySku[updatedItemSku].qty) - parseInt(newItemsBySku[updatedItemSku].qty);
             return item;
         }
@@ -89,8 +89,8 @@ define([
      * @param {Object} product - The product data object.
      */
     function pushToDataLayer(eventType, product) {
-        var qty = product.qty_diff || product.qty;
-        var eventData = {
+        const qty = product.qty_diff || product.qty;
+        const eventData = {
             'ecommerce': {}
         };
 
@@ -118,14 +118,14 @@ define([
         // On the first run, we need to handle the initialisation.
         if (_.isEmpty(prevCartData)) {
 
-            var firstEventFired = sessionStorage.getItem('sf_first_cart_event_fired');
+            const firstEventFired = sessionStorage.getItem('sf_first_cart_event_fired');
 
             if (cartData.items && cartData.items.length > 0) {
 
                 // Only process this as the first event if our session flag has NOT been set.
                 if (!firstEventFired) {
-                    var emptyCart = { items: [] };
-                    var addedProduct = findAddedProduct(cartData, emptyCart);
+                    const emptyCart = { items: [] };
+                    const addedProduct = findAddedProduct(cartData, emptyCart);
 
                     if (addedProduct) {
                         pushToDataLayer('add', addedProduct);
@@ -139,12 +139,12 @@ define([
             return;
         }
 
-        var addedProduct = findAddedProduct(cartData, prevCartData);
+        const addedProduct = findAddedProduct(cartData, prevCartData);
 
         if (addedProduct) {
             pushToDataLayer('add', addedProduct);
         } else {
-            var removedProduct = findRemovedProduct(cartData, prevCartData);
+            const removedProduct = findRemovedProduct(cartData, prevCartData);
             if (removedProduct) {
                 pushToDataLayer('remove', removedProduct);
             }

--- a/view/frontend/web/js/cart-tracking.js
+++ b/view/frontend/web/js/cart-tracking.js
@@ -1,0 +1,143 @@
+define([
+    'jquery',
+    'Magento_Customer/js/customer-data',
+    'underscore'
+], function ($, customerData, _) {
+    'use strict';
+
+    /**
+     * A variable to hold a deep copy of the cart data from the previous state.
+     * This is used to compare against the new state to detect changes.
+     */
+    var prevCartData = {};
+
+    /**
+     * Compares the new cart state with the old to find any added products or increased quantities.
+     * It uses the product SKU as a stable identifier for comparison.
+     * @param {Object} newCart - The new cart data object.
+     * @param {Object} oldCart - The previous cart data object.
+     * @returns {Object|null} The added product item or null if none is found.
+     */
+    function findAddedProduct(newCart, oldCart) {
+        var oldItems = oldCart.items || [];
+        var newItems = newCart.items || [];
+        var oldItemsBySku = _.indexBy(oldItems, 'product_sku');
+        var newItemsBySku = _.indexBy(newItems, 'product_sku');
+
+        // Case 1: A completely new SKU has been added to the cart.
+        var newItemSku = _.find(_.keys(newItemsBySku), function (sku) {
+            return !oldItemsBySku[sku];
+        });
+
+        if (newItemSku) {
+            return newItemsBySku[newItemSku];
+        }
+
+        // Case 2: The quantity of an existing SKU has been increased.
+        var updatedItemSku = _.find(_.keys(newItemsBySku), function (sku) {
+            return oldItemsBySku[sku] && parseInt(newItemsBySku[sku].qty) > parseInt(oldItemsBySku[sku].qty);
+        });
+
+        if (updatedItemSku) {
+            var item = $.extend(true, {}, newItemsBySku[updatedItemSku]);
+            item.qty_diff = parseInt(item.qty) - parseInt(oldItemsBySku[updatedItemSku].qty);
+            return item;
+        }
+
+        return null;
+    }
+
+    /**
+     * Compares the new cart state with the old to find any removed products or decreased quantities.
+     * It uses the product SKU as a stable identifier for comparison.
+     * @param {Object} newCart - The new cart data object.
+     * @param {Object} oldCart - The previous cart data object.
+     * @returns {Object|null} The removed product item or null if none is found.
+     */
+    function findRemovedProduct(newCart, oldCart) {
+        var oldItems = oldCart.items || [];
+        var newItems = newCart.items || [];
+        var oldItemsBySku = _.indexBy(oldItems, 'product_sku');
+        var newItemsBySku = _.indexBy(newItems, 'product_sku');
+
+        // Case 1: An SKU has been completely removed from the cart.
+        var removedItemSku = _.find(_.keys(oldItemsBySku), function (sku) {
+            return !newItemsBySku[sku];
+        });
+
+        if (removedItemSku) {
+            return oldItemsBySku[removedItemSku];
+        }
+
+        // Case 2: The quantity of an existing SKU has been decreased.
+        var updatedItemSku = _.find(_.keys(newItemsBySku), function (sku) {
+            return oldItemsBySku[sku] && parseInt(newItemsBySku[sku].qty) < parseInt(oldItemsBySku[sku].qty);
+        });
+
+        if (updatedItemSku) {
+            var item = $.extend(true, {}, oldItemsBySku[updatedItemSku]);
+            item.qty_diff = parseInt(oldItemsBySku[updatedItemSku].qty) - parseInt(newItemsBySku[updatedItemSku].qty);
+            return item;
+        }
+
+        return null;
+    }
+
+    /**
+     * Subscribes to changes in Magento's cart data.
+     * When a change is detected, it compares the new cart state with the previous one
+     * and pushes an 'add' or 'remove' event to the sfDataLayer.
+     */
+    customerData.get('cart').subscribe(function (cartData) {
+
+        // On the first run, just store the initial cart state.
+        if (_.isEmpty(prevCartData)) {
+            prevCartData = $.extend(true, {}, cartData);
+            return;
+        }
+
+        var addedProduct = findAddedProduct(cartData, prevCartData);
+
+        if (addedProduct) {
+            var qty = addedProduct.qty_diff || addedProduct.qty;
+
+            window.sfDataLayer = window.sfDataLayer || [];
+            window.sfDataLayer.push({
+                'ecommerce': {
+                    'add': {
+                        'sku': addedProduct.product_sku,
+                        'name': addedProduct.product_name,
+                        'price': addedProduct.product_price_value,
+                        'quantity': qty,
+                        'currency': window.sfData.currency || 'GBP',
+                        'link': addedProduct.product_url,
+                        'image_url': addedProduct.product_image ? addedProduct.product_image.src : ''
+                    }
+                }
+            });
+        } else {
+            var removedProduct = findRemovedProduct(cartData, prevCartData);
+            if (removedProduct) {
+                var qty = removedProduct.qty_diff || removedProduct.qty;
+
+                window.sfDataLayer = window.sfDataLayer || [];
+                window.sfDataLayer.push({
+                    'ecommerce': {
+                        'remove': {
+                            'sku': removedProduct.product_sku,
+                            'name': removedProduct.product_name,
+                            'price': removedProduct.product_price_value,
+                            'quantity': qty,
+                            'currency': window.sfData.currency || 'GBP',
+                            'link': removedProduct.product_url,
+                            'image_url': removedProduct.product_image ? removedProduct.product_image.src : ''
+                        }
+                    }
+                });
+            }
+        }
+
+        // After processing, store a deep copy of the new cart state for the next comparison.
+        prevCartData = $.extend(true, {}, cartData);
+    });
+});


### PR DESCRIPTION
[When I have AI Connect, I want my Magento 2 Integration to automatically track add to basket events, so that I can trigger email sequences.](https://app.shortcut.com/salesfire/story/14443/when-i-have-ai-connect-i-want-my-magento-2-integration-to-automatically-track-add-to-basket-events-so-that-i-can-trigger)

---

### Overview
Currently our Magento app doesn't track additions or removals from the basket by default. This hinders our ability to onboard these clients easily. This work adds that.

---

### Work
This work implements client side tracking for all basket events (additions, removals, quantity updates) by pushing the information to the sfDataLayer. I initially looked at a server-side approach but this led to a few issues due to the AJAX cart calls and running into issues with Magento's caching and updating item quantities in the basket.

---

### Considerations
Using 'cart' instead of 'basket' throughout to match Magento's naming convention

---

### Visual Evidence
<img width="1920" height="952" alt="Screenshot 2025-11-27 at 12 12 25" src="https://github.com/user-attachments/assets/484017d9-2b07-4fd2-b3b9-77a98a6c08a2" />
<img width="1920" height="952" alt="Screenshot 2025-11-27 at 12 12 15" src="https://github.com/user-attachments/assets/df42e451-1777-4b16-ba11-07d322eb3e8c" />

---

### Testing
- [x] Added product for the first time when the cartData and prevCartData don't exist
- [x] Adding further products
- [x] Adding products of different variants
- [x] Updating product quantities in the basket
- [x] Removing products from basket
- [x] Emptying out the basket 
