### PR TITLE
Magento 2 Salesfire feed does not include categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.12
+Released on 2025-12-02
+Released notes:
+
+- Fix feed not including categories in single store mode
+
 ### Salesfire v1.5.11
 Released on 2025-12-02
 Released notes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Released on 2025-12-02
 Released notes:
 
-- Fix feed not including categories in single store mode
+- Fix feed generator not including categories in single store mode
 
 ### Salesfire v1.5.11
 Released on 2025-12-02

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.11
+ * @version    1.5.12
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.10';
+        return '1.5.12';
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.11
+ * @version    1.5.12
  */
 class Generator
 {
@@ -490,7 +490,13 @@ class Generator
 
     public function getCategories($storeId)
     {
-        $rootCategoryId = $this->_storeManager->getStore($storeId)->getRootCategoryId();
+        $store = $storeId !== null
+            ? $this->_storeManager->getStore($storeId)
+            : $this->_storeManager->getDefaultStoreView();
+
+        $storeId = (int) $store->getId();
+        $rootCategoryId = (int) $store->getRootCategoryId();
+
         $categories = $this->_categoryCollectionFactory->create()
             ->setStoreId($storeId)
             ->addFieldToFilter('is_active', 1)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.11",
+    "version": "1.5.12",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
[Magento 2 Salesfire feed does not include categories
](https://app.shortcut.com/salesfire/story/15367/magento-2-salesfire-feed-does-not-include-categories)

---

### Overview
Some site are reporting categories missing from their Salesfire feed.

---

### Work
Update feed generation to include categories when site is in single store mode by getting default store id.