### PR TITLE
Fix PHP 8.2 compatibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.13
+Released on 2026-02-17
+Released notes:
+
+- Fix PHP 8.2 compatibility issues, defined properties in the Generator class to ensure proper initialisation and compatibility with newer PHP versions.
+
 ### Salesfire v1.5.12
 Released on 2025-12-02
 Released notes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Released on 2026-02-17
 Released notes:
 
-- Fix PHP 8.2 compatibility issues, defined properties in the Generator class to ensure proper initialisation and compatibility with newer PHP versions.
+- Fix PHP 8.2 compatibility issues.
 
 ### Salesfire v1.5.12
 Released on 2025-12-02

--- a/Controller/Adminhtml/Feed/Generate.php
+++ b/Controller/Adminhtml/Feed/Generate.php
@@ -15,13 +15,14 @@ use Salesfire\Salesfire\Helper\Feed\Generator;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.3.3
+ * @version    1.5.13
  */
 class Generate extends \Magento\Backend\App\Action
 {
-
     protected $resultPageFactory;
     protected $jsonHelper;
+    protected $logger;
+    protected $feedGenerator;
 
     /**
      * Constructor

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.12';
+        return '1.5.13';
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.12
+ * @version    1.5.13
  */
 class Data extends AbstractHelper
 {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.12",
+    "version": "1.5.13",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
[sc-15727]

This pull request updates the Salesfire Magento2 module to version 1.5.13, primarily addressing PHP 8.2 compatibility issues. The main focus is on ensuring proper property initialisation in the `Generator` class and updating version references throughout the codebase.

**PHP 8.2 Compatibility and Version Updates:**

* Updated changelog in `CHANGELOG.md` to document the release of v1.5.13, highlighting fixes for PHP 8.2 compatibility and property initialisation in the `Generator` class.
* Bumped version numbers from 1.5.12 to 1.5.13 in `composer.json`, `Helper/Data.php`, and the header of `Controller/Adminhtml/Feed/Generate.php` to reflect the new release.
* Added new protected properties `$logger` and `$feedGenerator` to the `Generate` controller to support proper initialisation and future compatibility.