### PR TITLE
Fix PHP compatibility issues

### DIFF
--- a/Block/Adminhtml/FeedUrl.php
+++ b/Block/Adminhtml/FeedUrl.php
@@ -35,6 +35,8 @@ class FeedUrl extends Field
      */
     protected $_storeManager;
 
+    protected $_helperData;
+
     /**
      * @param Context $context
      * @param StoreManagerInterface $storeManager

--- a/Block/Adminhtml/FeedUrl.php
+++ b/Block/Adminhtml/FeedUrl.php
@@ -16,7 +16,7 @@ use Salesfire\Salesfire\Helper\Data;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.15
+ * @version    1.5.14
  */
 class FeedUrl extends Field
 {

--- a/Block/Adminhtml/Logs.php
+++ b/Block/Adminhtml/Logs.php
@@ -17,7 +17,7 @@ use \Salesfire\Salesfire\Helper\Logger\Logger;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.15
+ * @version    1.5.14
  */
 class Logs extends Field
 {
@@ -40,6 +40,8 @@ class Logs extends Field
      * @var Logger
      */
     protected $_logger;
+
+    protected $_helperData;
 
     /**
      * @param Context $context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.14
+Released on 2026-02-18
+Released notes:
+
+- Fix feed generator string escape issues.
+
 ### Salesfire v1.5.13
 Released on 2026-02-17
 Released notes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Released on 2026-02-18
 Released notes:
 
-- Fix feed generator string escape issues.
+- Fix PHP compatibility issues.
 
 ### Salesfire v1.5.13
 Released on 2026-02-17

--- a/Controller/Config/Index.php
+++ b/Controller/Config/Index.php
@@ -6,7 +6,7 @@ namespace Salesfire\Salesfire\Controller\Config;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.15
+ * @version    1.5.14
  */
 class Index extends \Magento\Framework\App\Action\Action
 {
@@ -27,7 +27,7 @@ class Index extends \Magento\Framework\App\Action\Action
         $this->helperData        = $helperData;
         $this->_storeManager     = $storeManager;
 
-        return parent::__construct($context);
+        parent::__construct($context);
     }
 
     public function getHelper()

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.13
+ * @version    1.5.14
  */
 class Data extends AbstractHelper
 {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.13';
+        return '1.5.14';
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -39,7 +39,7 @@ class Data extends AbstractHelper
         $this->storeManager = $storeManager;
         $this->productMetadata = $productMetadata;
 
-        return parent::__construct($context);
+        parent::__construct($context);
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.12
+ * @version    1.5.14
  */
 class Generator
 {
@@ -110,7 +110,7 @@ class Generator
 
     public function escapeString($text)
     {
-        return html_entity_decode(trim($text));
+        return html_entity_decode(trim($text ?? ''));
     }
 
     public function execute()

--- a/Helper/Logger/Logger.php
+++ b/Helper/Logger/Logger.php
@@ -13,21 +13,23 @@ use LimitIterator;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.4.0
+ * @version    1.5.14
  */
-class Logger extends \Monolog\Logger
+class Logger
 {
+    protected $logger;
+
     const MAX_SIZE =  1024 * 1024 * 50; // 50 megabytes
 
     public function __construct($name = 'salesfire', array $handlers = [], array $processors = [])
     {
-        parent::__construct($name, $handlers, $processors);
+        $this->logger = new \Monolog\Logger($name, $handlers, $processors);
     }
 
     protected function getPath()
     {
         /** @var \App\Logger\Handler $handlers */
-        $handlers = $this->getHandlers();
+        $handlers = $this->logger->getHandlers();
 
         if (! is_array($handlers) || count($handlers) === 0) {
             return null;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.13",
+    "version": "1.5.14",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Story details: https://app.shortcut.com/salesfire/story/15727

This pull request updates the Salesfire Magento 2 module to version 1.5.14, focusing on PHP compatibility improvements and minor refactoring. The most significant changes include updating version numbers throughout the codebase, enhancing PHP compatibility in helper methods, and refactoring the custom logger class for better maintainability.

**Version Updates:**
* Bumped module version to `1.5.14` in all relevant files, including `composer.json`, PHP class docblocks, and the `getVersion()` method in `Helper/Data.php`. 
* Added a changelog entry for v1.5.14, noting PHP compatibility fixes.

**PHP Compatibility and Code Quality Improvements:**
* Updated the `escapeString` method in `Helper/Feed/Generator.php` to handle potential null values safely, preventing errors with `trim($text ?? '')`.
* Removed unnecessary `return` statements after `parent::__construct()` calls in constructors, aligning with PHP best practices.

**Logger Refactor:**
* Refactored `Helper/Logger/Logger.php` to wrap the Monolog logger instead of extending it directly, improving maintainability and future compatibility.

**Internal Consistency:**
* Added the `$_helperData` property to `Block/Adminhtml/FeedUrl.php` and `Block/Adminhtml/Logs.php` for consistency and potential future use.