### PR TITLE
Strip out the cached image path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.16
+Released on 2026-02-24
+Released notes:
+
+- Remove the cached image path from the cart tracking data. 
+
 ### Salesfire v1.5.15
 Released on 2026-02-24
 Released notes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Released on 2026-02-24
 Released notes:
 
-- Remove the cached image path from the cart tracking data. 
+- Update cart tracking to use the original image instead of the thumbnail.
 
 ### Salesfire v1.5.15
 Released on 2026-02-24

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.15
+ * @version    1.5.16
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.15';
+        return '1.5.16';
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.15",
+    "version": "1.5.16",
     "license": [
         "OSL-3.0"
     ],

--- a/view/frontend/web/js/cart-tracking.js
+++ b/view/frontend/web/js/cart-tracking.js
@@ -101,7 +101,12 @@ define([
             'quantity': qty,
             'currency': window.sfData.currency || 'GBP',
             'link': product.product_url,
-            'image_url': product.product_image ? product.product_image.src : ''
+            'image_url': product.product_image
+                ? product.product_image.src.replace(
+                    /\/media\/catalog\/product\/cache\/[^/]+\/+/,
+                    '/media/catalog/product/'
+                )
+                : ''
         };
 
         window.sfDataLayer = window.sfDataLayer || [];

--- a/view/frontend/web/js/cart-tracking.js
+++ b/view/frontend/web/js/cart-tracking.js
@@ -101,7 +101,7 @@ define([
             'quantity': qty,
             'currency': window.sfData.currency || 'GBP',
             'link': product.product_url,
-            'image_url': product.product_image
+            'image_url': product.product_image && product.product_image.src
                 ? product.product_image.src.replace(
                     /\/media\/catalog\/product\/cache\/[^/]+\/+/,
                     '/media/catalog/product/'


### PR DESCRIPTION
Story details: https://app.shortcut.com/salesfire/story/15840

This pull request updates the Salesfire extension to version 1.5.16, with a primary focus on improving cart tracking data by removing the cached image path from product image URLs. This ensures that the image URLs sent in cart tracking are cleaner and more consistent. The update also includes standard version bumps in documentation and helper methods.

**Cart tracking improvements:**

* Modified the construction of the `image_url` property in cart tracking data to strip out the cached image path segment from product image URLs, ensuring only the direct path is used.

**Version updates:**

* Updated the module version from `1.5.15` to `1.5.16` in both the file header and the `getVersion()`
* Added a new entry for version 1.5.16, documenting the removal of the cached image path from cart tracking data.