### PR TITLE
Add Breeze theme compatibility for JS modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.17
+Released on 2026-02-24
+Released notes:
+
+- Add Breeze theme compatibility for JS modules (cart-tracking.js and sfgetid.js).
+
 ### Salesfire v1.5.16
 Released on 2026-02-24
 Released notes:

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.16
+ * @version    1.5.17
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.16';
+        return '1.5.17';
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.16",
+    "version": "1.5.17",
     "license": [
         "OSL-3.0"
     ],

--- a/view/frontend/layout/breeze_default.xml
+++ b/view/frontend/layout/breeze_default.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+  <body>
+    <referenceBlock name="breeze.js">
+      <arguments>
+        <argument name="bundles" xsi:type="array">
+          <item name="dynamic" xsi:type="array">
+            <item name="items" xsi:type="array">
+
+              <!-- Cart Tracking -->
+              <item name="Salesfire_Salesfire/js/cart-tracking" xsi:type="array">
+                <item name="path" xsi:type="string">Salesfire_Salesfire/js/cart-tracking</item>
+                <item name="export" xsi:type="array">
+                  <item name="sf-cart-tracking-alias" xsi:type="string">sfcarttracking</item>
+                </item>
+                <item name="load" xsi:type="array">
+                  <item name="onRequire" xsi:type="boolean">true</item>
+                </item>
+              </item>
+
+              <!-- SfGetId -->
+              <item name="Salesfire_Salesfire/js/sfgetid" xsi:type="array">
+                <item name="path" xsi:type="string">Salesfire_Salesfire/js/sfgetid</item>
+                <item name="export" xsi:type="array">
+                  <item name="sf-getid-alias" xsi:type="string">sfgetid</item>
+                </item>
+                <item name="load" xsi:type="array">
+                  <item name="onRequire" xsi:type="boolean">true</item>
+                </item>
+              </item>
+
+            </item>
+          </item>
+        </argument>
+      </arguments>
+    </referenceBlock>
+  </body>
+</page>


### PR DESCRIPTION
### Problem

The Breeze theme replaces Magento's RequireJS with its own lightweight module loader, which ignores `requirejs-config.js` entirely. Without a `breeze_default.xml`, Breeze never loads either JS module:

- `require(['sfcarttracking'])`  silently ignored, no ATB events pushed to `sfDataLayer`
- `require(['sfgetid'], function(sfgetid) { sfgetid(); })`  callback fires with `undefined`, throws `TypeError: sfgetid is not a function`

<img width="736" height="86" alt="Screenshot 2026-02-24 at 13 13 31" src="https://github.com/user-attachments/assets/36eeae7a-055c-4f97-825a-b69a110924ce" />

View events and transactions are unaffected because they use inline `sfDataLayer.push()` rendered by PHP.

### How `Script.php` renders these (`_toHtml`, line 210):

```php
return $this->initSfGetIdScript($nonce) . $this->initSfAddToCartScript($nonce) . $formatter->toScriptTag($nonce);
```

| Output | Method | Uses `require()`? | Works on Breeze? |
|---|---|---|---|
| Session tracking | `initSfGetIdScript()` | Yes  `require(['sfgetid'])` | **No** (without this fix) |
| ATB tracking | `initSfAddToCartScript()` | Yes  `require(['sfcarttracking'])` | **No** (without this fix) |
| View/transaction events | `$formatter->toScriptTag()` | No  inline `sfDataLayer.push()` | Yes |

### What `breeze_default.xml` does

Registers both modules with Breeze's dynamic bundle, replacing the role of `requirejs-config.js`:

- **`path`**  tells Breeze where the JS file lives
- **`export`**  creates the alias mapping (e.g. `sfcarttracking` → `Salesfire_Salesfire/js/cart-tracking`)
- **`load.onRequire`**  tells Breeze to fetch the module when `require()` is called


### Local testing

Installed Breeze v2.28.1 locally on Magento 2.4.8-p3 (Docker, Luma theme) to verify the fix before deploying to any customer site. After adding `breeze_default.xml` and running `breeze:compile`:

- Both `sfgetid.js` and `cart-tracking.js` loaded as separate `<script>` tags
- `TypeError: sfgetid is not a function` no longer thrown
- ATB event (`ecommerce.add`) appeared in `sfDataLayer` after adding to cart
- `$.extend(true, ...)` deep clone works correctly with Cash (Breeze's jQuery alternative)
- Session tracking (`sf_cuid`) stored in localStorage and pushed to `sfDataLayer`

All dependencies confirmed compatible: `Magento_Customer/js/customer-data`, `underscore` (`_.indexBy`), `jquery` (Cash), `mage/url`.



https://github.com/user-attachments/assets/5f76c789-12f2-4b20-af3b-4677ae48301e





