### PR TITLE
Fix product feed to respect magento visibility settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.18
+Released on 2026-03-16
+Released notes:
+
+- Fix product feed to respect Magento visibility settings. Products with visibility set to "Catalog" only are now excluded from the feed.
+
 ### Salesfire v1.5.17
 Released on 2026-02-24
 Released notes:

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.17
+ * @version    1.5.18
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.17';
+        return '1.5.18';
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -528,7 +528,7 @@ class Generator
             ->create()
             ->addAttributeToSelect('*')
             ->addAttributeToFilter('status', 1)
-            ->addAttributeToFilter('visibility', ['neq' => 1])
+            ->addAttributeToFilter('visibility', ['in' => [3, 4]])
             ->setStoreId($storeId)
             ->addStoreFilter($storeId)
             ->addMinimalPrice()

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.17",
+    "version": "1.5.18",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
[SC-15828]

Clients needed a way to bulk-exclude products from Salesfire Search by changing the product's Visibility setting in their Magento admin. In Magento, setting a product's visibility to "Catalog" (instead of "Catalog, Search") should remove it from search results. Clients expected this to carry through to Salesfire Search automatically, rather than having to manually exclude each product one-by-one in the Salesfire dashboard. They were finding it unmanageable to exclude products on an ad hoc basis, especially in bulk.

## Root Cause

**File:** `magento2/Helper/Feed/Generator.php` — `getVisibleProducts()` method (line ~531)

The product collection filter was too permissive:

```php
// BEFORE (bug): only excluded visibility=1 (Not Visible Individually)
->addAttributeToFilter('visibility', ['neq' => 1])
```

This meant products with visibility=2 ("Catalog" only) were still being exported to the Salesfire feed and appearing in search results.

### Magento 2 Visibility Values

| Value | Constant | Meaning | Was Exported? | Should Be Exported? |
|-------|----------|---------|---------------|---------------------|
| 1 | `VISIBILITY_NOT_VISIBLE` | Not Visible Individually | No | No |
| 2 | `VISIBILITY_IN_CATALOG` | Catalog only | **Yes (bug)** | **No** |
| 3 | `VISIBILITY_IN_SEARCH` | Search only | Yes | Yes |
| 4 | `VISIBILITY_BOTH` | Catalog, Search | Yes | Yes |

Constants defined in `\Magento\Catalog\Model\Product\Visibility`.


https://github.com/user-attachments/assets/9c9d12ce-681a-4560-aa13-38b0d48cc2d4

