### PR TITLE
add fall back to parent attribute value for additional attributes on …

### DIFF
--- a/Block/Script.php
+++ b/Block/Script.php
@@ -110,6 +110,7 @@ class Script extends Template
         $script .= "    sfgetid();\n";
         $script .= "});\n";
         $script .= "</script>\n";
+
         return $script;
     }
 

--- a/Block/Script.php
+++ b/Block/Script.php
@@ -6,6 +6,7 @@ use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\ObjectManagerInterface;
 use \Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\StoreManagerInterface;
+use Zend_Log_Writer_Stream;
 
 /**
  * Salesfire Script Block
@@ -110,7 +111,7 @@ class Script extends Template
         $script .= "    sfgetid();\n";
         $script .= "});\n";
         $script .= "</script>\n";
-    
+
         return $script;
     }
 

--- a/Block/Script.php
+++ b/Block/Script.php
@@ -6,7 +6,6 @@ use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\ObjectManagerInterface;
 use \Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\StoreManagerInterface;
-use Zend_Log_Writer_Stream;
 
 /**
  * Salesfire Script Block
@@ -111,7 +110,6 @@ class Script extends Template
         $script .= "    sfgetid();\n";
         $script .= "});\n";
         $script .= "</script>\n";
-
         return $script;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Salesfire v1.5.19
+Released on 2026-04-27
+Released notes:
+
+- Fall back to parent attribute value for additional attributes on child (simple) products where attribute value isn't available.
+
 ### Salesfire v1.5.18
 Released on 2026-03-16
 Released notes:

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -9,7 +9,7 @@ use Magento\Store\Model\ScopeInterface;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.18
+ * @version    1.5.19
  */
 class Data extends AbstractHelper
 {
@@ -49,7 +49,7 @@ class Data extends AbstractHelper
      */
     public function getVersion()
     {
-        return '1.5.18';
+        return '1.5.19';
     }
 
     /**

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -7,7 +7,7 @@ namespace Salesfire\Salesfire\Helper\Feed;
  *
  * @category   Salesfire
  * @package    Salesfire_Salesfire
- * @version    1.5.14
+ * @version    1.5.19
  */
 class Generator
 {

--- a/Helper/Feed/Generator.php
+++ b/Helper/Feed/Generator.php
@@ -349,6 +349,9 @@ class Generator
                                                 }
 
                                                 $attribute_text = $this->getAttributeValue($storeId, $childProduct, $attribute);
+                                                if (! $attribute_text) {
+                                                    $attribute_text = $this->getAttributeValue($storeId, $product, $attribute);
+                                                }
                                                 if ($attribute_text) {
                                                     $attributes[$attribute] = $attribute_text;
                                                 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "salesfire/magento2",
     "description": "Salesfire Magento2",
     "type": "magento2-module",
-    "version": "1.5.18",
+    "version": "1.5.19",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
[Given that "style" Attribute Code is assigned in Magento feed settings, when I look at Salesfire feed, then I can see that <style> attribute is only applied to simple products](https://app.shortcut.com/salesfire/story/16702/given-that-style-attribute-code-is-assigned-in-magento-feed-settings-when-i-look-at-salesfire-feed-then-i-can-see-that-style)
---

### Overview

Child products weren't having Additional attributes being applied to them inline with the value of the attribute on the parent. 

---

### Work

akin to how we fall back to the parents colour attribute value - I have implemented a fallback for all attributes on a child product. when iterating through the childs attributes, if no value is found - apply the value from the parents attribute. 